### PR TITLE
Add Python 3 Compatibility

### DIFF
--- a/hacks
+++ b/hacks
@@ -1,11 +1,9 @@
 #!/usr/bin/python
 import sys
-import json
 import requests
 import datetime
 import calendar
 import base64
-from ctypes import c_longlong as ll
 
 no_of_arguments = len(sys.argv)
 
@@ -15,7 +13,7 @@ day = datetime.datetime.now().day
 
 class Hackanswers:
     def fetch(self):
-        print "Please wait a few seconds while we fetch the details for you..."
+        print("Please wait a few seconds while we fetch the details for you...")
         self.list1 = []
         self.list2 = []
         self.list3 = []
@@ -25,7 +23,7 @@ class Hackanswers:
             r = requests.get(url)
             if r.status_code != 200:
                 raise RuntimeError
-            decoded_content = base64.b64decode(json.loads(r.content)['content'])
+            decoded_content = base64.b64decode(r.json()['content']).decode()
             return decoded_content.split('\n')
 
         # list1[r1,r2]
@@ -35,36 +33,36 @@ class Hackanswers:
             url_1_2 = "http://www.hackalist.org/api/1.0/"+str(year+1)+"/"+"01"+".json"
         r1 = requests.get(url_1_1)
         if r1.status_code != 200:
-            print "Couldn't fetch hackalist.org [1]"
+            print("Couldn't fetch hackalist.org [1]")
         else:
-            self.list1.append(json.loads(r1.content))
+            self.list1.append(r1.json())
         r2 = requests.get(url_1_2)
         if r2.status_code != 200:
-            print "Couldn't fetch hackalist.org [2]"
+            print("Couldn't fetch hackalist.org [2]")
         else:
-            self.list1.append(json.loads(r2.content))
+            self.list1.append(r2.json())
 
         # list2[r]
         url_2 = "https://api.github.com/repos/japacible/Hackathon-Calendar/contents/README.md?ref=master"
         try:
             self.list2.append(splitcontent(url_2))
         except RuntimeError as e:
-            print "Couldn't fetch Hackathon-Calendar"
+            print("Couldn't fetch Hackathon-Calendar")
 
         # list3[r]
         url_3 = "http://hackathonwatch.com:80/api//hackathons/coming.json?page=1"
         r = requests.get(url_3)
         if r.status_code!=200:
-            print "Couldn't fetch hackathonwatch.com"
+            print("Couldn't fetch hackathonwatch.com")
         else:
-            self.list3.append(json.loads(r.content))
+            self.list3.append(r.json())
 
         # list4[r]
         url_4 = "https://api.github.com/repos/waseem18/Hackathons-In-India/contents/README.md"
         try:
             self.list4.append(splitcontent(url_4))
         except RuntimeError as e:
-            print "Couldn't fetch Hackathons-In-India"
+            print("Couldn't fetch Hackathons-In-India")
 
 hacks_result = []
 hacks_answer = Hackanswers()
@@ -175,7 +173,7 @@ def HackathonsList3(city):
         hack = {}
         hack['Title'] = i['name']
         hack['URL'] = i['public_url']
-        duration = long(i['finish_timestamp'])-long(i['start_timestamp'])
+        duration = int(i['finish_timestamp'])-int(i['start_timestamp'])
         hack['Duration'] = str(duration)
         no_of_hours = duration/3600
         hack['Starts on'] = datetime.datetime.fromtimestamp(i['start_timestamp']).strftime('%Y-%m-%d %H:%M:%S')
@@ -223,11 +221,11 @@ def HackathonsList4(city):
             hacks_result.append(hack)
 
 def print_help():
-   print "Usage:"
-   print "     1. Just typing 'hacks' outputs the list of Hackathons in or near your location!\n"
-   print "     2. Command 'hacks California' gives the list of Hackathons in California.\n"
-   print "     3. We consider all arguments after first arguments as a single argument(city name)).\n"
-   print "     4. So command 'hacks New York' too gives the list of Hackathons in New York.\n"
+   print("Usage:")
+   print("     1. Just typing 'hacks' outputs the list of Hackathons in or near your location!\n")
+   print("     2. Command 'hacks California' gives the list of Hackathons in California.\n")
+   print("     3. We consider all arguments after first arguments as a single argument(city name)).\n")
+   print("     4. So command 'hacks New York' too gives the list of Hackathons in New York.\n")
 
 def runLists(data):
     for f in [HackathonsList1, HackathonsList2, HackathonsList3, HackathonsList4]:
@@ -241,7 +239,7 @@ if no_of_arguments == 1:
    #Outputs details of upcoming hackathons in the location of the user.
    url = "http://ip-api.com/json"
    r = requests.get(url)
-   data = json.loads(r.content)
+   data = r.json()
    city = str(data['city'])
    region = data['regionName']
    country = data['country']
@@ -249,24 +247,24 @@ if no_of_arguments == 1:
    runLists(city)
    runLists(region)
    if len(hacks_result):
-     print "\n"
+     print("\n")
      for i in hacks_result:
-        print "Title     : "+i['Title']
-        print "URL       : "+i['URL']
-        print "Starts on : "+i['Starts on']
+        print("Title     : "+i['Title'])
+        print("URL       : "+i['URL'])
+        print("Starts on : "+i['Starts on'])
         if i['Ends on']:
-           print "Ends on   : "+i['Ends on']
-        print "Location  : "+i['location']
-        print "-----------------------------------------------------------------"
+           print("Ends on   : "+i['Ends on'])
+        print("Location  : "+i['location'])
+        print("-----------------------------------------------------------------")
    if len(hacks_result)==0:
-     print "Looking for Hackathons in %s, %s..." % (region, country)
+     print("Looking for Hackathons in %s, %s..." % (region, country))
      runLists(region)
      runLists(country)
    if len(hacks_result)==0:
-     print "Looking for Hackathons in %s..." % (country)
+     print("Looking for Hackathons in %s..." % (country))
      runLists(country)
    if len(hacks_result)==0:
-     print "We couldn't find hackathons in %s, %s.\nTry refining the search location Or try the command, 'hacks locationName'.\nEg: hacks California" % (city, country)
+     print("We couldn't find hackathons in %s, %s.\nTry refining the search location Or try the command, 'hacks locationName'.\nEg: hacks California" % (city, country))
 
 
 elif no_of_arguments == 2:
@@ -275,24 +273,24 @@ elif no_of_arguments == 2:
       print_help()
       sys.exit(0)
    elif city=="--version":
-       print "Hacks  - 0.1.1\n"
-       print "https://github.com/waseem18/hacks\n"
+       print("Hacks  - 0.1.1\n")
+       print("https://github.com/waseem18/hacks\n")
        exit(0)
    hacks_answer.fetch()
    runLists(city)
    if len(hacks_result):
-     print "\n-----------------------------------------------------------------"
+     print("\n-----------------------------------------------------------------")
      for i in hacks_result:
-        print "Title     : "+i['Title']
-        print "URL       : "+i['URL']
-        print "Starts on : "+i['Starts on']
+        print("Title     : "+i['Title'])
+        print("URL       : "+i['URL'])
+        print("Starts on : "+i['Starts on'])
         if 'Ends on' in i:
-           print "Ends on   : "+i['Ends on']
-        print "Location  : "+i['location']
-        print "-----------------------------------------------------------------"
-     print ""
+           print("Ends on   : "+i['Ends on'])
+        print("Location  : "+i['location'])
+        print("-----------------------------------------------------------------")
+     print("")
    else:
-     print "We couldn't find hackathons in %s.\nTry refining the search location or find more hackathons at https://github.com/japacible/Hackathon-Calendar" % (city)
+     print("We couldn't find hackathons in %s.\nTry refining the search location or find more hackathons at https://github.com/japacible/Hackathon-Calendar" % (city))
 
 
 
@@ -307,14 +305,14 @@ elif no_of_arguments > 2:
    hacks_answer.fetch()
    runLists(city)
    if len(hacks_result):
-     print "\n"
+     print("\n")
      for i in hacks_result:
-        print "Title     : "+i['Title']
-        print "URL       : "+i['URL']
-        print "Starts on : "+i['Starts on']
+        print("Title     : "+i['Title'])
+        print("URL       : "+i['URL'])
+        print("Starts on : "+i['Starts on'])
         if 'Ends on' in i:
-           print "Ends on   : "+i['Ends on']
-        print "Location  : "+i['location']
-        print "-----------------------------------------------------------------"
+           print("Ends on   : "+i['Ends on'])
+        print("Location  : "+i['location'])
+        print("-----------------------------------------------------------------")
    else:
-     print "We couldn't find hackathons in %s.\nTry refining the search location or find more hackathons at https://github.com/japacible/Hackathon-Calendar" % (city)
+     print("We couldn't find hackathons in %s.\nTry refining the search location or find more hackathons at https://github.com/japacible/Hackathon-Calendar" % (city))

--- a/hacks
+++ b/hacks
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import requests
 import datetime


### PR DESCRIPTION
On Arch Linux, the `python` executable points to Python 3. This script had compatibility problems with Python 3 (mostly related to `json` and the `print` statement). These changes modify the code to be compatible with Python 3.

One could also explicitly state `python2` on the shebang line as described in [PEP 0394](https://www.python.org/dev/peps/pep-0394/).
